### PR TITLE
Add Jest tests for follower count utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,12 @@ Planned features for upcoming releases:
 - Added test-positioning.js script to verify UI elements are correctly positioned
 - Added window resize handling to maintain proper positioning in all scenarios
 - Added debug mode that can be enabled with: `window.autoCommenterStatus.debug(true)`
+## Running Tests
+
+Automated tests are written using [Jest](https://jestjs.io/). After installing dependencies, run:
+
+```bash
+npm test
+```
+
+This will execute the test suite located in the `tests/` directory.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hashtag-research-with-suggestions",
+  "version": "1.0.0",
+  "description": "![Extension Logo](ext-logo.png)",
+  "main": "auto-commenter-settings.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/popup.js
+++ b/popup.js
@@ -637,6 +637,11 @@ function formatFollowerCount(count) {
   }
 }
 
+// Export functions for testing environments
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { parseFollowerCount, formatFollowerCount };
+}
+
 // Tab switching functionality
 document.addEventListener('DOMContentLoaded', () => {
   // Set up tab switching

--- a/tests/parseFollowerCount.test.js
+++ b/tests/parseFollowerCount.test.js
@@ -1,0 +1,23 @@
+const { parseFollowerCount } = require('../popup');
+
+describe('parseFollowerCount', () => {
+  test('handles plain numbers', () => {
+    expect(parseFollowerCount('1,234 followers')).toBe(1234);
+    expect(parseFollowerCount('56789')).toBe(56789);
+  });
+
+  test('handles K suffix', () => {
+    expect(parseFollowerCount('12K followers')).toBe(12000);
+    expect(parseFollowerCount('3.5K')).toBe(3500);
+  });
+
+  test('handles M suffix', () => {
+    expect(parseFollowerCount('2M followers')).toBe(2000000);
+    expect(parseFollowerCount('1.2M')).toBe(1200000);
+  });
+
+  test('handles invalid inputs', () => {
+    expect(parseFollowerCount('N/A')).toBe(0);
+    expect(parseFollowerCount(undefined)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- export `parseFollowerCount` and `formatFollowerCount` for testing
- initialize npm and add a Jest test suite
- document how to run the tests in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684038d78414832a9dca8df444d9ad34